### PR TITLE
Rename JSON deserializer functions

### DIFF
--- a/lib/src/entity_state.dart
+++ b/lib/src/entity_state.dart
@@ -32,11 +32,11 @@ class EntityState<T> {
 
   factory EntityState.fromJson(
     Map<String, dynamic> json,
-    Deserializer<T> deserializer,
+    Deserializer<T> fromJsonT,
   ) =>
       EntityState(
           entities: (json['entities'] as Map<String, dynamic>).map(
-            (key, props) => MapEntry<String, T>(key, deserializer(props)),
+            (key, props) => MapEntry<String, T>(key, fromJsonT(props)),
           ),
           ids: List<String>.from(json['ids']));
 }

--- a/lib/src/remote_entity_state.dart
+++ b/lib/src/remote_entity_state.dart
@@ -62,11 +62,11 @@ class RemoteEntityState<T> extends EntityState<T> {
 
   factory RemoteEntityState.fromJson(
     Map<String, dynamic> json,
-    Deserializer<T> deserializer,
+    Deserializer<T> fromJsonT,
   ) =>
       RemoteEntityState(
         entities: (json['entities']).map<String, T>(
-              (key, props) => MapEntry<String, T>(key, deserializer(props)),
+              (key, props) => MapEntry<String, T>(key, fromJsonT(props)),
             ) ??
             {},
         ids: json['ids'] != null ? List<String>.from(json['ids']) : [],


### PR DESCRIPTION
I have my Redux state serialisable to use it with redux_persist, but I get errors from json_serializable:

```
[SEVERE] json_serializable on lib/state/root_state.dart (cached):

Expecting a `fromJson` constructor with exactly one positional parameter. The only extra parameters allowed are functions of the form `T Function(Object?) fromJsonT` where `T` is a type parameter of the targe
t type.
package:redux_entity/src/remote_entity_state.dart:63:29
   ╷
63 │   factory RemoteEntityState.fromJson(
   │                             ^^^^^^^^
   ╵
[SEVERE] Failed after 63ms
```

This PR is to keep json_serializable happy, as it checks the name of additional methods provided to the `fromJson` factory[^1]. It's not a breaking change as it's just renaming a positional argument.

[^1]: https://github.com/google/json_serializable.dart/issues/870